### PR TITLE
Update for new Slack scopes

### DIFF
--- a/app/authenticators/slack.js
+++ b/app/authenticators/slack.js
@@ -13,7 +13,7 @@ export default Base.extend({
     if (config.environment !== 'production') {
       return Ember.RSVP.resolve({
         accessToken: 'token',
-        scope: 'identify,read'
+        scope: 'identify,users:read'
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttz",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "time zones for your Slack team",
   "private": true,
   "directories": {


### PR DESCRIPTION
More restrictive OAuth2 scopes are a good thing, so use them.